### PR TITLE
Redefinition must now be explicit

### DIFF
--- a/akernel/code.py
+++ b/akernel/code.py
@@ -21,10 +21,11 @@ code_assign = dedent(
         else:
             a = ipyx.X(b)
     else:
-        if isinstance(b, ipyx.X):
-            a = b
-        elif isinstance(a, ipyx.X):
-            a.v = b
+        if isinstance(a, ipyx.X):
+            if isinstance(b, ipyx.X):
+                a.v = b.v
+            else:
+                a.v = b
         else:
             a = b
     """
@@ -51,14 +52,14 @@ def get_assign_body(lhs: str, rhs):
     body[0].body[0].body[0].value = rhs  # type: ignore
     body[0].body[0].orelse[0].targets[0].id = lhs  # type: ignore
     body[0].body[0].orelse[0].value.args[0] = rhs  # type: ignore
-    body[0].orelse[0].test.args[0] = rhs  # type: ignore
-    body[0].orelse[0].body[0].targets[0].id = lhs  # type: ignore
-    body[0].orelse[0].body[0].value = rhs  # type: ignore
-    body[0].orelse[0].orelse[0].test.args[0].id = lhs  # type: ignore
-    body[0].orelse[0].orelse[0].body[0].targets[0].value.id = lhs  # type: ignore
-    body[0].orelse[0].orelse[0].body[0].value = rhs  # type: ignore
-    body[0].orelse[0].orelse[0].orelse[0].targets[0].id = lhs  # type: ignore
-    body[0].orelse[0].orelse[0].orelse[0].value = rhs  # type: ignore
+    body[0].orelse[0].test.args[0].id = lhs  # type: ignore
+    body[0].orelse[0].body[0].test.args[0] = rhs  # type: ignore
+    body[0].orelse[0].body[0].body[0].targets[0].value.id = lhs  # type: ignore
+    body[0].orelse[0].body[0].body[0].value.value = rhs  # type: ignore
+    body[0].orelse[0].body[0].orelse[0].targets[0].value.id = lhs  # type: ignore
+    body[0].orelse[0].body[0].orelse[0].value = rhs  # type: ignore
+    body[0].orelse[0].orelse[0].targets[0].id = lhs  # type: ignore
+    body[0].orelse[0].orelse[0].value = rhs  # type: ignore
     return body
 
 

--- a/akernel/tests/test_react_code.py
+++ b/akernel/tests/test_react_code.py
@@ -16,10 +16,11 @@ def test_assign_constant():
                 a = 1
             else:
                 a = ipyx.X(1)
-        elif isinstance(1, ipyx.X):
-            a = 1
         elif isinstance(a, ipyx.X):
-            a.v = 1
+            if isinstance(1, ipyx.X):
+                a.v = 1 .v
+            else:
+                a.v = 1
         else:
             a = 1
         """
@@ -42,10 +43,11 @@ def test_assign_variable():
                 a = b
             else:
                 a = ipyx.X(b)
-        elif isinstance(b, ipyx.X):
-            a = b
         elif isinstance(a, ipyx.X):
-            a.v = b
+            if isinstance(b, ipyx.X):
+                a.v = b.v
+            else:
+                a.v = b
         else:
             a = b
         """
@@ -70,10 +72,11 @@ def test_assign_call():
                 a = ipyx.F(foo)(b)
             else:
                 a = ipyx.X(ipyx.F(foo)(b))
-        elif isinstance(ipyx.F(foo)(b), ipyx.X):
-            a = ipyx.F(foo)(b)
         elif isinstance(a, ipyx.X):
-            a.v = ipyx.F(foo)(b)
+            if isinstance(ipyx.F(foo)(b), ipyx.X):
+                a.v = ipyx.F(foo)(b).v
+            else:
+                a.v = ipyx.F(foo)(b)
         else:
             a = ipyx.F(foo)(b)
         """
@@ -100,10 +103,11 @@ def test_assign_nested_call():
                 a = ipyx.F(foo)(ipyx.F(bar)(b))
             else:
                 a = ipyx.X(ipyx.F(foo)(ipyx.F(bar)(b)))
-        elif isinstance(ipyx.F(foo)(ipyx.F(bar)(b)), ipyx.X):
-            a = ipyx.F(foo)(ipyx.F(bar)(b))
         elif isinstance(a, ipyx.X):
-            a.v = ipyx.F(foo)(ipyx.F(bar)(b))
+            if isinstance(ipyx.F(foo)(ipyx.F(bar)(b)), ipyx.X):
+                a.v = ipyx.F(foo)(ipyx.F(bar)(b)).v
+            else:
+                a.v = ipyx.F(foo)(ipyx.F(bar)(b))
         else:
             a = ipyx.F(foo)(ipyx.F(bar)(b))
         """

--- a/examples/reactivity.ipynb
+++ b/examples/reactivity.ipynb
@@ -24,9 +24,9 @@
    "id": "466f6c01-19cb-4c34-ade9-1802086a85c5",
    "metadata": {},
    "source": [
-    "But the variable `a` *is* defined, its *value* isn't (`None`).\n",
+    "But the variable `a` *is* defined, its *value* is not (`None`).\n",
     "\n",
-    "The value of `b` is also not defined."
+    "Because `b` was used in the definition of `a`, `b` is now implicitly defined, and its value is also undefined."
    ]
   },
   {
@@ -191,7 +191,17 @@
    "id": "c5b0c4eb-7b27-43dc-a03a-069bd0b8ff41",
    "metadata": {},
    "source": [
-    "Redefining a variable is also allowed. Previous representations still refer to their previous definitions, though (see cell 7)."
+    "For a variable to be redefined, it must be deleted first. Previous representations still refer to the previous definition, though (see cell 7)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "64cb76bc-725b-4087-869c-4c540e8f2dc7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "del y"
    ]
   },
   {


### PR DESCRIPTION
Automatic redefinition is ambiguous, and the Zen of Python says that "explicit is better than implicit" :smile: 
So now a react variable must be deleted before being redefined. If not, then its value will "temporarily" be set to the RHS (until another change updates its value), but I'm not sure we want to advertise this behavior.